### PR TITLE
Custom table partitioning and improved search

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -10,29 +10,40 @@ task :create_logs_tables do
 
   LogsTables.create_merge_table(force: force)
 
-  (0..6).each do |i|
-    date = i.days.from_now
-    LogsTables.create_date_table(date, force: force)
+  time_to = 1.week.from_now.utc
+  time = LogsTables.round_time_to_partition(Time.zone.now)
+
+  while time <= time_to do
+    LogsTables.create_partition_table(time, force: force)
+
+    time = LogsTables.next_time_partition(time)
   end
 end
 
 
 task :insert_fixtures do
-  s = CSV.generate do |csv|
-    csv << [LogsTables::TIMESTAMP_ATTRIBUTE, LogsTables::NSEC_ATTRIBUTE, *LogsTables::KUBERNETES_ATTRIBUTES.keys,
-            'labels.names', 'labels.values',
-            'string_fields.names', 'string_fields.values','number_fields.names', 'number_fields.values',
-            'boolean_fields.names', 'boolean_fields.values', 'null_fields.names']
+  tables_ranges = LogsTables.split_range_to_tables((LogsTables::PARTITION_PERIOD * 3).hours.ago.utc, Time.zone.now.utc)
 
-    CSV.foreach('fixtures/fake_data.tsv', col_sep: "\t") do |r|
-      o = []
-      o << (Time.zone.now - rand(1_000).to_i.seconds).utc.strftime('%Y-%m-%d %H:%M:%S')
-      o << rand(10**6).to_i
-      o += r
-      csv << o
+  tables_ranges.each do |table, fromto|
+    LogsTables.create_partition_table(fromto.first) unless ::Clickhouse.connection.exists_table(table)
+
+    s = CSV.generate do |csv|
+      csv << [LogsTables::TIMESTAMP_ATTRIBUTE, LogsTables::NSEC_ATTRIBUTE, *LogsTables::KUBERNETES_ATTRIBUTES.keys,
+        'labels.names', 'labels.values',
+        'string_fields.names', 'string_fields.values','number_fields.names', 'number_fields.values',
+        'boolean_fields.names', 'boolean_fields.values', 'null_fields.names']
+
+      CSV.foreach('fixtures/fake_data.tsv', col_sep: "\t") do |r|
+        time = rand(Range.new(*fromto))
+        o = []
+        o << time.strftime('%Y-%m-%d %H:%M:%S')
+        o << rand(10**6).to_i
+        o += r
+
+        csv << o
+      end
     end
-  end
-  table = LogsTables.send(:date_table_name)
 
-  Clickhouse.connection.insert_rows(table, csv: s)
+    Clickhouse.connection.insert_rows(table, csv: s)
+  end
 end

--- a/application.rb
+++ b/application.rb
@@ -36,7 +36,7 @@ module Loghouse
                 end
 
       begin
-        @to_clickhouse = @query.to_clickhouse
+        @query.validate_query!
       rescue LoghouseQuery::BadFormat => e
         @error = "Bad query format: #{e}"
       rescue LoghouseQuery::BadTimeFormat => e

--- a/console
+++ b/console
@@ -2,6 +2,7 @@
 def reload!
   load './application.rb'
   Time.zone = Loghouse::TIME_ZONE
+  User.current = 'admin'
 end
 
 reload!

--- a/lib/log_entry.rb
+++ b/lib/log_entry.rb
@@ -1,33 +1,32 @@
 class LogEntry
   def self.from_result_set(result_set)
-    result_set.map { |r| new r, result_set.names }
+    result_set.map { |r| new r.to_hash }
   end
 
   attr_reader :timestamp, :labels, :strings, :numbers, :booleans, :nulls
   LogsTables::KUBERNETES_ATTRIBUTES.keys.each { |k| attr_reader k }
 
-  def initialize(row, names)
-    @names          = names
-    @row            = row
-    @timestamp      = row[names.index('timestamp')].change(nsec: row[names.index('nsec')])
+  def initialize(row)
+    @row       = row
+    @timestamp = row['timestamp'].change(nsec: row['nsec'])
 
     LogsTables::KUBERNETES_ATTRIBUTES.keys.each do |k|
-      instance_variable_set("@#{k}", row[names.index(k.to_s)])
+      instance_variable_set("@#{k}", row[k.to_s])
     end
 
     @labels   = fields_to_hash('labels')
     @strings  = fields_to_hash('string_fields')
     @numbers  = fields_to_hash('number_fields')  { |v| v.to_i }
     @booleans = fields_to_hash('boolean_fields') { |v| v.to_i == 1 }
-    @nulls    = row[names.index('null_fields.names')].map(&:to_sym)
+    @nulls    = row['null_fields.names'].map(&:to_sym)
   end
 
   protected
 
   def fields_to_hash(name)
     res      = {}
-    f_names  = @row[@names.index("#{name}.names")]
-    f_values = @row[@names.index("#{name}.values")]
+    f_names  = @row["#{name}.names"]
+    f_values = @row["#{name}.values"]
     f_names.each_with_index do |n, i|
       v = f_values[i]
       res[n.to_sym] = block_given? ? yield(v) : v

--- a/lib/loghouse_query.rb
+++ b/lib/loghouse_query.rb
@@ -24,7 +24,7 @@ class LoghouseQuery
     position:   nil
   }.freeze # Trick for all-attributes-hash in correct order in insert
 
-  attr_accessor :attributes
+  attr_accessor :attributes, :persisted
 
   def initialize(attrs = {})
     attrs.symbolize_keys!
@@ -47,14 +47,14 @@ class LoghouseQuery
     [attributes[:order_by], "#{LogsTables::TIMESTAMP_ATTRIBUTE} DESC", "#{LogsTables::NSEC_ATTRIBUTE} DESC"].compact.join(', ')
   end
 
-  def result
-    @result ||= LogEntry.from_result_set ::Clickhouse.connection.select_rows(to_clickhouse)
+  def validate_query!
+    parsed_query # sort of validation: will fail if query is not correct
   end
 
   def validate!
-    to_clickhouse # sort of validation: will fail if queries is not correct
-
     super
+
+    validate_query!
   end
 end
 

--- a/lib/loghouse_query/clickhouse.rb
+++ b/lib/loghouse_query/clickhouse.rb
@@ -5,25 +5,57 @@ class LoghouseQuery
   module Clickhouse
     extend ActiveSupport::Concern
 
-    def to_clickhouse
+    def result
+      @result ||= begin
+        lim = limit
+        split_range_to_tables.sort_by {|table, fromto| fromto.last }.reverse.map do |table, fromto|
+          next unless lim.positive? && ::Clickhouse.connection.exists_table(table)
+
+          sql = to_clickhouse(table, *fromto, lim)
+
+          res = LogEntry.from_result_set ::Clickhouse.connection.query(sql)
+
+          lim -= res.count
+          res
+        end.compact.flatten
+      end
+    end
+
+    def to_clickhouse(table, from, to, lim = nil)
       params = {
         select: '*',
-        from: LogsTables::LOGS_TABLE,
+        from: table,
         order: order_by,
-        limit: limit
+        limit: lim
       }
-      if (where = to_clickhouse_where)
+      if (where = to_clickhouse_where(from, to))
         params[:where] = where
       end
 
-      params
+      ::Clickhouse.connection.to_select_query(params)
     end
 
     protected
 
-    def to_clickhouse_time(time)
-      time = Time.zone.parse(time) if time.is_a? String
+    def split_range_to_tables
+      LogsTables.split_range_to_tables(parsed_time_from, parsed_time_to)
+    end
 
+    def time_comparation(time, comparation)
+      if time.nsec.zero?
+        "#{LogsTables::TIMESTAMP_ATTRIBUTE} #{comparation}= #{to_clickhouse_time(time)}"
+      else
+        '(' + [
+          [
+            [LogsTables::TIMESTAMP_ATTRIBUTE, to_clickhouse_time(time)].join(' = '),
+            [LogsTables::NSEC_ATTRIBUTE, time.nsec].join(" #{comparation} ")
+          ].join(' AND '),
+          [LogsTables::TIMESTAMP_ATTRIBUTE, to_clickhouse_time(time)].join(" #{comparation} "),
+        ].join(') OR (') + ')'
+      end
+    end
+
+    def to_clickhouse_time(time)
       "toDateTime('#{time.utc.strftime('%Y-%m-%d %H:%M:%S')}')"
     end
 
@@ -33,14 +65,13 @@ class LoghouseQuery
       namespaces.map { |ns| "namespace = '#{ns}'" }.join(' OR ')
     end
 
-    def to_clickhouse_where
+    def to_clickhouse_where(from = nil, to = nil)
       where_parts = []
       where_parts << Query.new(parsed_query[:query]).to_s if parsed_query
 
-      where_parts << "#{LogsTables::TIMESTAMP_ATTRIBUTE} >= #{to_clickhouse_time parsed_time_from}" if parsed_time_from
-      where_parts << "#{LogsTables::TIMESTAMP_ATTRIBUTE} <= #{to_clickhouse_time parsed_time_to}" if parsed_time_to
+      where_parts << time_comparation(from, '>') if from
+      where_parts << time_comparation(to, '<') if to
 
-      where_parts << to_clickhouse_pagination_where
       where_parts << to_clickhouse_namespaces
       where_parts.compact!
 

--- a/lib/loghouse_query/csv.rb
+++ b/lib/loghouse_query/csv.rb
@@ -1,9 +1,12 @@
 class LoghouseQuery
   module CSV
     def csv_result(shown_keys = nil)
-      return "" if result.blank?
+      sql = to_clickhouse(LogsTables::TABLE_NAME, parsed_time_from, parsed_time_to)
+      res = LogEntry.from_result_set ::Clickhouse.connection.query(sql)
 
-      res = result.map do |r|
+      return "" if res.blank?
+
+      res = res.map do |r|
         x = { 'timestamp' => r.timestamp.strftime("%Y-%m-%d %H:%M:%S.%N") }
         LogsTables::KUBERNETES_ATTRIBUTES.keys.each { |k| x[k.to_s] = r.send(k) }
         r.labels.each { |l, v| x["~#{l}"] = v }

--- a/lib/loghouse_query/pagination.rb
+++ b/lib/loghouse_query/pagination.rb
@@ -6,34 +6,28 @@ class LoghouseQuery
     alias :limit :per_page
 
     def paginate(newer_than: nil, older_than: nil, per_page: nil)
-      @newer_than  = newer_than if newer_than.present?
-      @older_than  = older_than if older_than.present? && !@newer_than
-      @per_page    = per_page.to_i if per_page.present?
+      @newer_than = Time.zone.parse(newer_than).utc if newer_than.present?
+      @older_than = Time.zone.parse(older_than).utc if older_than.present? && !@newer_than
+      @per_page   = per_page.to_i if per_page.present?
 
       @per_page ||= DEFAULT_PER_PAGE
       self
     end
 
-    def to_clickhouse_pagination_where
-      if newer_than
-        time_comparation newer_than, '>'
-      elsif older_than
-        time_comparation older_than, '<'
-      end
+    def parsed_time_from
+      s = super
+
+      return s if newer_than.blank?
+
+      [s, newer_than].max
     end
 
-    private
+    def parsed_time_to
+      s = super
 
-    def time_comparation(time, comparation)
-      timestamp, nsec = time.split('.')
+      return s if older_than.blank?
 
-      [
-        [
-          [LogsTables::TIMESTAMP_ATTRIBUTE, to_clickhouse_time(timestamp)].join(' = '),
-          [LogsTables::NSEC_ATTRIBUTE, nsec].join(" #{comparation} ")
-        ].join(' AND '),
-        [LogsTables::TIMESTAMP_ATTRIBUTE, to_clickhouse_time(timestamp)].join(" #{comparation} "),
-      ].join(' OR ')
+      [s, older_than].min
     end
   end
 end

--- a/lib/loghouse_query/permissions.rb
+++ b/lib/loghouse_query/permissions.rb
@@ -9,7 +9,7 @@ class LoghouseQuery
       Clickhouse::Query.new(parser.parse(permissions_query)[:query]).to_s
     end
 
-    def to_clickhouse_where
+    def to_clickhouse_where(from = nil, to = nil)
       "(#{[super, to_clickhouse_permissions].join(') AND (')})"
     end
   end

--- a/lib/loghouse_query/storable.rb
+++ b/lib/loghouse_query/storable.rb
@@ -69,7 +69,9 @@ class LoghouseQuery
       protected
 
       def build_from_row(row)
-        new id: row[0], name: row[1], namespaces: row[2], query: row[3], time_from: row[4], time_to: row[5], position: row[6]
+        lq = new id: row[0], name: row[1], namespaces: row[2], query: row[3], time_from: row[4], time_to: row[5], position: row[6]
+        lq.persisted = true
+        lq
       end
     end
 

--- a/lib/loghouse_query_time_p.rb
+++ b/lib/loghouse_query_time_p.rb
@@ -41,6 +41,6 @@ class LoghouseQueryTimeP < Parslet::Parser
       time = Time.zone.parse(str)
       raise LoghouseQuery::BadTimeFormat.new("#{str}: #{e}") if time.blank?
     end
-    time
+    time.utc
   end
 end

--- a/views/_filter_form.erb
+++ b/views/_filter_form.erb
@@ -1,15 +1,6 @@
 <nav class="navbar navbar-double navbar-inverse navbar-fixed-bottom" class="bottomNavBar">
   <form id="filter-form" action="/query" method="get">
     <!-- search params popovers -->
-    <% if @to_clickhouse %>
-      <div id="toClickhouse" class="search-params-popover">
-        <div class="panel panel-default">
-          <div class="panel-body">
-            <pre><%= h @to_clickhouse %></pre>
-          </div>
-        </div>
-      </div>
-    <% end %>
     <div id="hideShowKeys" class="search-params-popover">
       <div class="panel panel-default">
         <div class="panel-body">
@@ -51,7 +42,7 @@
         </div>
         <div class="col-xs-1">
           <div class="form-group" data-toggle="tooltip" title="Save query">
-            <a role="button" class="btn btn-link btn-link-alt<% if !@query %> disabled<% end %>" <% if @query %> id="save-query"<% end %>><span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span></a>
+            <a role="button" class="btn btn-link btn-link-alt<% if @query.persisted %> disabled<% end %>" <% if !@query.persisted %> id="save-query"<% end %>><span class="glyphicon glyphicon-floppy-disk" aria-hidden="true"></span></a>
           </div>
           <div class="form-group" data-toggle="tooltip" title="Save result as CSV">
             <a role="button" class="btn btn-link btn-link-alt" <% if @query %> id="save-as-csv"<% end %>><span class="glyphicon glyphicon-download-alt" aria-hidden="true"></span></a>
@@ -85,9 +76,6 @@
         <div class="col-xs-2" align="right">
           <div class="form-group" data-toggle="tooltip" title="Add breakpoint">
             <a role="button" class="btn btn-link btn-link-alt" id="breakpointBtn"><span class="glyphicon glyphicon-eject" aria-hidden="true"></span></a>
-          </div>
-          <div class="form-group" data-toggle="tooltip" title="Show clickhouse info">
-            <a class="btn btn-link btn-link-alt <% if @to_clickhouse %>search-params-btn<% else %>disabled<% end %>" role="button" data-target="#toClickhouse"><span class="glyphicon glyphicon-info-sign" aria-hidden="true"></span></a>
           </div>
         </div>
       </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -10,13 +10,11 @@
 </div>
 <div id="result">
   <div class="logs-result logs-result_default-theme">
-  <% if @to_clickhouse %>
     <div class="logs-result__container"
         data-entry-oldest='<%= @query.result.length > 0 ? @query.result.last.timestamp.strftime("%Y-%m-%d %H:%M:%S.%N") : Time.now.strftime("%Y-%m-%d %H:%M:%S.%N") %>'
         data-entry-newest='<%= @query.result.length > 0 ? @query.result.first.timestamp.strftime("%Y-%m-%d %H:%M:%S.%N") : Time.now.strftime("%Y-%m-%d %H:%M:%S.%N") %>'>
-        <%= erb :_result %>
-      </div>
+      <%= erb :_result %>
     </div>
-  <% end %>
+  </div>
 </div>
 <%= erb :_filter_form %>


### PR DESCRIPTION
* Custom partitioning, using `LOGS_TABLES_PARTITION_PERIOD` variable, in hours. 24 must be divisible by this value for now, so tables always can start with 00 hours (it's skipped for 24). Default is 24, as it was.
* Search now looks only in nececcary partition tables, based on time range and pagination. 
* The only search that looks in merge-table is CSV, where there is no pagination.
* Rake migrations updated to fit new scheme.