### PR TITLE
Limit greedy search by 2 partition periods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem 'chronic'
 gem 'kubeclient'
 
 gem 'pry', group: :development
+gem 'dotenv', require: 'dotenv/load', group: :development

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
     concurrent-ruby (1.0.5)
     domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
+    dotenv (2.2.1)
     erubis (2.7.0)
     faraday (0.14.0)
       multipart-post (>= 1.2, < 3)
@@ -103,6 +104,7 @@ DEPENDENCIES
   activesupport
   chronic
   clickhouse!
+  dotenv
   json
   kubeclient
   parslet

--- a/lib/loghouse_query/clickhouse.rb
+++ b/lib/loghouse_query/clickhouse.rb
@@ -73,11 +73,17 @@ class LoghouseQuery
     def result_from_seek_to
       lim = limit || Pagination::DEFAULT_PER_PAGE
 
+      seek_to_max_periods = 2
+
+      max_search_before = parsed_seek_to - (LogsTables::PARTITION_PERIOD.hours * seek_to_max_periods)
+      max_search_after  = parsed_seek_to + (LogsTables::PARTITION_PERIOD.hours * seek_to_max_periods)
+      max_search_after = Time.zone.now if max_search_after > Time.zone.now
+
       # search before part
-      before = result_older(parsed_seek_to, lim)
+      before = result_older(parsed_seek_to, lim, max_search_before)
 
       # search after part
-      after = result_newer(parsed_seek_to, lim, Time.zone.now)
+      after = result_newer(parsed_seek_to, lim, max_search_after)
 
       res = after.last([before.count, lim / 2].min)
       res += before.first(lim - res.count)


### PR DESCRIPTION
Greedy search used to search through every partition table until it gets LIMIT of records. When search query returns nothing it takes a lot of time to search every existing table so loghouse goes to timeout. This PR fix this behavior by limiting greedy search to 2 partition tables to the past and to the future of searched time.