### PR TITLE
Bump Chart version to 0.2.2

### DIFF
--- a/charts/loghouse/Chart.yaml
+++ b/charts/loghouse/Chart.yaml
@@ -1,5 +1,5 @@
 name: loghouse
-version: 0.0.1
+version: 0.2.2
 description: Loghouse (Fluentd, Clickhouse, Tabix, Loghouse) for collect and prepare
              logs for Kubernetes cluster.
 keywords:


### PR DESCRIPTION
Since image version uses .Chart.Version now, it'd be wise to set Chart version according to container versions.