### PR TITLE
Ensure that Kubernetes metadata "host" field is not null

### DIFF
--- a/charts/loghouse/templates/fluentd/fluentd-configmap.yaml
+++ b/charts/loghouse/templates/fluentd/fluentd-configmap.yaml
@@ -88,7 +88,7 @@ data:
         # static fields
         source                 "kubernetes"
         namespace              ${record["kubernetes"]["namespace_name"]}
-        host                   ${record["kubernetes"]["host"]}
+        host                   ${record["kubernetes"]["host"] || ENV["K8S_NODE_NAME"]}
         pod_name               ${record["kubernetes"]["pod_name"]}
         container_name         ${record["kubernetes"]["container_name"]}
         stream                 ${record["stream"]}

--- a/charts/loghouse/templates/fluentd/fluentd.yaml
+++ b/charts/loghouse/templates/fluentd/fluentd.yaml
@@ -36,6 +36,10 @@ spec:
           value: {{ .Values.clickhouse.db | quote }}
         - name: K8S_LOGS_TABLE
           value: {{ .Values.clickhouse.table | quote }}
+        - name: K8S_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         resources:
           limits:
             memory: {{ .Values.fluentd.resources.limits.memory }}


### PR DESCRIPTION
## Synopsis

There are situations in some our workloads that `host` Kubernetes metadata field is set to `null` when Fluentd tries to insert rows into ClickHouse via `insert_ch.sh` script, and so fails with
```
Code: 26. DB::Exception: Cannot parse JSON string: expected opening quote: (at row 1)
```
error as [`host` field is not `Nullable()`](https://github.com/flant/loghouse/blob/d35e27490c8c584757dc8d5c38b7a481843949e8/lib/logs_tables.rb#L13).  
This leads to logs losses and introduces problems with performance.

For example, the logs of GitLab jobs running on the Kubernetes cluster:
```bash
$ cat some.log
{"stream":"stderr","timestamp":1534409488,"nsec":266532412,"source":"kubernetes","namespace":"gitlab-jobs","host":null,"pod_name":"runner-9100a1a0-project-22-concurrent-095lc9","container_name":"svc-0","labels.names":[],"labels.values":[],"string_fields.names":["log"],"string_fields.values":["time=\"2018-08-16T08:51:28Z\" level=info msg=\"shim reaped\" id=e6ee7fb9cfa728b87bc925ca7e62066c416b57eae13a0304fabba07c74c6d1df \n"],"number_fields.names":[],"number_fields.values":[],"boolean_fields.names":[],"boolean_fields.values":[],"null_fields.names":[]}
$ insert_ch.sh some.log
Code: 26. DB::Exception: Cannot parse JSON string: expected opening quote: (at row 1)
```

I believe this happens when Fluentd Kubernetes metadata filter plugin tries to get info about some Pod read from log, but that Pod doesn't exist anymore at all.




## Solution

Set `K8S_NODE_NAME` to Fluentd container as [Fluentd Kubernetes metadata filter plugin recommends](https://github.com/fabric8io/fluent-plugin-kubernetes_metadata_filter#environment-variables-for-kubernetes).

And set value of this environment variable directly when plugin returns `null` value.