### PR TITLE
Chart: set apiVersion for CronJob according to kube version

### DIFF
--- a/charts/loghouse/templates/_helpers.tpl
+++ b/charts/loghouse/templates/_helpers.tpl
@@ -1,0 +1,10 @@
+{{/*
+CronJob api version
+*/}}
+{{- define "CronJob.apiVersion" -}}
+{{- if semverCompare ">=1.8" .Capabilities.KubeVersion.GitVersion -}}
+"batch/v1beta1"
+{{- else -}}
+"batch/v2alpha1"
+{{- end -}}
+{{- end -}}

--- a/charts/loghouse/templates/loghouse/loghouse-cronjob.yaml
+++ b/charts/loghouse/templates/loghouse/loghouse-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v2alpha1
+apiVersion: {{ template "CronJob.apiVersion" $ }}
 kind: CronJob
 metadata:
   name: {{ .Chart.Name }}-tables


### PR DESCRIPTION
More generalized approach for CronJob apiVersion.

Fixes #37  (PRs #81 #94)