### PR TITLE
Fix clickhouse version

### DIFF
--- a/images/clickhouse/Dockerfile
+++ b/images/clickhouse/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:16.04
 
 ARG repository="deb http://repo.yandex.ru/clickhouse/deb/stable/ main/"
-ARG version=\*
+ARG version=18.10.3
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https tzdata && \


### PR DESCRIPTION
We should fix a specified version of clickhouse. Otherwise we can not control the performance of the image. For example on version 18.12.* we have broken image with error `bash: /usr/bin/clickhouse-server: Operation not permitted` 