### PR TITLE
Use 'networking.k8s.io/v1' apiVersion for Ingress

### DIFF
--- a/charts/loghouse/templates/_helpers.tpl
+++ b/charts/loghouse/templates/_helpers.tpl
@@ -2,7 +2,9 @@
 Ingress api version
 */}}
 {{- define "Ingress.apiVersion" -}}
-{{- if semverCompare ">=1.14" .Capabilities.KubeVersion.GitVersion -}}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion -}}
+"networking.k8s.io/v1"
+{{- else if semverCompare ">=1.14" .Capabilities.KubeVersion.GitVersion -}}
 "networking.k8s.io/v1beta1"
 {{- else -}}
 "extensions/v1beta1"

--- a/charts/loghouse/templates/clickhouse/clickhouse-ingress.yaml
+++ b/charts/loghouse/templates/clickhouse/clickhouse-ingress.yaml
@@ -29,9 +29,19 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.clickhouse.path }}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+        pathType: ImplementationSpecific
+{{- end }}
         backend:
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: clickhouse
+            port:
+              name: http
+{{- else }}
           serviceName: clickhouse
           servicePort: http
+{{- end }}
 {{- if .Values.ingress.enable_https }}
   tls:
   - hosts:

--- a/charts/loghouse/templates/loghouse/loghouse-ingress.yaml
+++ b/charts/loghouse/templates/loghouse/loghouse-ingress.yaml
@@ -29,9 +29,19 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.loghouse.path }}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+        pathType: ImplementationSpecific
+{{- end }}
         backend:
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: loghouse
+            port:
+              name: http
+{{- else }}
           serviceName: loghouse
           servicePort: http
+{{- end }}
 {{- if .Values.ingress.enable_https }}
   tls:
   - hosts:

--- a/charts/loghouse/templates/tabix/tabix-ingress.yaml
+++ b/charts/loghouse/templates/tabix/tabix-ingress.yaml
@@ -29,9 +29,19 @@ spec:
     http:
       paths:
       - path: {{ .Values.ingress.tabix.path }}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+        pathType: ImplementationSpecific
+{{- end }}
         backend:
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion }}
+          service:
+            name: tabix
+            port:
+              name: http
+{{- else }}
           serviceName: tabix
           servicePort: http
+{{- end }}
 {{- if .Values.ingress.enable_https }}
   tls:
   - hosts:


### PR DESCRIPTION
This PR adds usage of `apiVersion: networking.k8s.io/v1` in Helm chart's Ingress resources for >=1.19 Kubernetes.